### PR TITLE
Webhook handler honors `:icon_url` attribute

### DIFF
--- a/files/default/slack_handler_webhook.rb
+++ b/files/default/slack_handler_webhook.rb
@@ -70,8 +70,20 @@ class Chef::Handler::Slack < Chef::Handler
     http.use_ssl = true
     http.verify_mode = OpenSSL::SSL::VERIFY_NONE
     req = Net::HTTP::Post.new(uri.path, 'Content-Type' => 'application/json')
-    req.body = { username: @username, text: message, icon_emoji: @icon_emoji }.to_json
+    req.body = request_body(message)
     http.request(req)
+  end
+
+  def request_body(message)
+    body = {}
+    body[:username] = @username
+    body[:text] = message
+    if @icon_url
+      body[:icon_url] = @icon_url
+    else
+      body[:icon_emoji] = @icon_emoji
+    end
+    body.to_json
   end
 
   def run_status_human_readable


### PR DESCRIPTION
`:icon_url` is intended to take precedence over `:icon_emoji`, however, `:icon_url` is not being considered in the webhook handler.
