### PR TITLE
Move exception from message to text attachment

### DIFF
--- a/files/default/slack_handler_webhook.rb
+++ b/files/default/slack_handler_webhook.rb
@@ -41,7 +41,7 @@ class Chef::Handler::Slack < Chef::Handler
         if run_status.success?
           slack_message(" :white_check_mark: Chef client run #{run_status_human_readable} on #{run_status.node.name} #{run_status_detail(webhook['detail_level'])}", webhook['url']) unless webhook['fail_only']
         else
-          slack_message(" :skull: Chef client run #{run_status_human_readable} on #{run_status.node.name} #{run_status_detail(webhook['detail_level'])} \n #{run_status.exception}", webhook['url'])
+          slack_message(" :skull: Chef client run #{run_status_human_readable} on #{run_status.node.name} #{run_status_detail(webhook['detail_level'])}", webhook['url'], run_status.exception)
         end
       end
     end
@@ -64,17 +64,17 @@ class Chef::Handler::Slack < Chef::Handler
     end
   end
 
-  def slack_message(message, webhook)
+  def slack_message(message, webhook, text_attachment = nil)
     uri = URI.parse(webhook)
     http = Net::HTTP.new(uri.host, uri.port)
     http.use_ssl = true
     http.verify_mode = OpenSSL::SSL::VERIFY_NONE
     req = Net::HTTP::Post.new(uri.path, 'Content-Type' => 'application/json')
-    req.body = request_body(message)
+    req.body = request_body(message, text_attachment)
     http.request(req)
   end
 
-  def request_body(message)
+  def request_body(message, text_attachment)
     body = {}
     body[:username] = @username
     body[:text] = message
@@ -83,6 +83,7 @@ class Chef::Handler::Slack < Chef::Handler
     else
       body[:icon_emoji] = @icon_emoji
     end
+    body[:attachments] = [{ text: text_attachment }] unless text_attachment.nil?
     body.to_json
   end
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -8,3 +8,6 @@ long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          "0.3.0"
 
 depends "chef_handler"
+
+source_url 'https://github.com/rackspace-cookbooks/chef-slack_handler' if respond_to?(:source_url)
+issues_url 'https://github.com/rackspace-cookbooks/chef-slack_handler/issues' if respond_to?(:issues_url)


### PR DESCRIPTION
Sometimes Chef will have a lengthy exception stack trace.  When this happens on 2 or 3 hosts it can flood a slack channel with a lot of text.  Moving the exception from the message body to a text attachment allows slack to collapse the message and show a "show more" link.

See the `text` section of https://api.slack.com/docs/attachments for more info
