### PR TITLE
Update webhooks for the cases of showing more information when there is a failure

### DIFF
--- a/files/default/slack_handler_webhook.rb
+++ b/files/default/slack_handler_webhook.rb
@@ -68,7 +68,7 @@ class Chef::Handler::Slack < Chef::Handler
   end
 
   def message(context)
-    "Chef client run #{run_status_human_readable} on #{run_status.node.name}#{run_status_cookbook_detail(context['cookbook_detail_level'])}#{run_status_detail(context['message_detail_level'])}"
+    "Chef client run #{run_status_human_readable} on #{run_status.node.name}#{run_status_cookbook_detail(context['cookbook_detail_level'])}#{run_status_message_detail(context['message_detail_level'])}"
   end
 
   def run_status_message_detail(message_detail_level)
@@ -114,7 +114,7 @@ class Chef::Handler::Slack < Chef::Handler
     cookbook_detail_level ||= @cookbook_detail_level
     case cookbook_detail_level
     when "all"
-      cookbooks = run_status.run_context.cookbook_collection
+      cookbooks = Chef.run_context.cookbook_collection
       " using cookbooks #{cookbooks.values.map { |x| x.name.to_s + ' ' + x.version }}"
     end
   end


### PR DESCRIPTION
Addresses:

```
WARN: Failed to send message to Slack: undefined method `run_status_detail' for #<Chef::Handler::Slack:0x000000025a1048>
         - Chef::Handler::Slack
```

By calling `run_status_message_detail` function in the web hooks case.  Could very well go the other way and name consistent `run_status_detail` across the two files `slack_handler.rb` and `slack_handler_webhook.rb`

AND

```
WARN: Failed to send message to Slack: undefined method `cookbook_collection' for nil:NilClass
           - Chef::Handler::Slack
```

In the case where there is an failed status in run_status, it appears that `run_status.run_context` is Nil at the time that it is accessed.

you can see this from adding one each of these lines on a failure.

```
Chef::Log.error("********* Chef.run_context is #{Chef.run_context.inspect}")
Chef::Log.error("********* run_status.run_context is #{run_status.run_context.inspect}")
```

Unsure if this is the intention for Chef, but in an example in the [docs](https://docs.chef.io/handlers.html) they use `Chef.run_context...`
