### PR TITLE
webhook: check http response

### DIFF
--- a/files/default/slack_handler_webhook.rb
+++ b/files/default/slack_handler_webhook.rb
@@ -80,7 +80,12 @@ class Chef::Handler::Slack < Chef::Handler
     http.verify_mode = OpenSSL::SSL::VERIFY_NONE
     req = Net::HTTP::Post.new(uri.path, 'Content-Type' => 'application/json')
     req.body = request_body(message, text_attachment)
-    http.request(req)
+    res = http.request(req)
+    # responses can be:
+    # "Bad token"
+    # "invalid_payload"
+    # "ok"
+    raise res.body unless res.body == 'ok'
   end
 
   def request_body(message, text_attachment)


### PR DESCRIPTION
will make slack webhook errors visible:

```
[2016-06-01T13:43:49+03:00] WARN: Failed to send message to Slack: Bad token
```
