### PR TITLE
fixed run_context issue

### DIFF
--- a/files/default/slack_handler_util.rb
+++ b/files/default/slack_handler_util.rb
@@ -50,7 +50,7 @@ class SlackHandlerUtil
   def run_status_cookbook_detail(context = {})
     case context['cookbook_detail_level'] || @default_config[:cookbook_detail_level]
     when "all"
-      cookbooks = run_context.cookbook_collection
+      cookbooks = Chef.run_context.cookbook_collection
       " using cookbooks #{cookbooks.values.map { |x| x.name.to_s + ' ' + x.version }}"
     end
   end


### PR DESCRIPTION
Fixes #38 

The slack_handler was broken [here](https://github.com/rackspace-cookbooks/chef-slack_handler/commit/81cb4459394a98e39b7428eaa0660503e6861c0b#diff-a958532b6fb029dca72a349ce64335ecL52). `run_context` needs to be called on `Chef`.

I've tested this myself and it fixes issue #38. 