### PR TITLE
Fix reporting exceptions with libyajl2

### DIFF
--- a/files/default/slack_handler_webhook.rb
+++ b/files/default/slack_handler_webhook.rb
@@ -106,7 +106,7 @@ class Chef::Handler::Slack < Chef::Handler
       body[:icon_emoji] = @icon_emoji
     end
     body[:channel] = @channel if @channel
-    body[:attachments] = [{ text: text_attachment }] unless text_attachment.nil?
+    body[:attachments] = [{ text: text_attachment.to_s }] unless text_attachment.nil?
     body.to_json
   end
 end


### PR DESCRIPTION
Some chef versions, like 11.14.2, may end up installing libyajl2, instead of
yajl-ruby, and it seems they treat exceptions differently. The end result is
that the webhook fails with "invalid_payload" and the json seems to be invalid.

By just doing a "to_s", it always work (it works fine on a string too).