### PR TITLE
check Chef for run_context compatibility

### DIFF
--- a/files/default/slack_handler_util.rb
+++ b/files/default/slack_handler_util.rb
@@ -50,7 +50,10 @@ class SlackHandlerUtil
   def run_status_cookbook_detail(context = {})
     case context['cookbook_detail_level'] || @default_config[:cookbook_detail_level]
     when "all"
-      cookbooks = run_context.cookbook_collection
+      if Chef.respond_to?(:run_context)
+        cookbooks = Chef.run_context.cookbook_collection
+      else
+        cookbooks = run_context.cookbook_collection
       " using cookbooks #{cookbooks.values.map { |x| x.name.to_s + ' ' + x.version }}"
     end
   end


### PR DESCRIPTION
This PR fixes #38 the same way that #41 does, but adds a compatibility check for the `run_context` method suggested by @glensc. 