### PR TITLE
Hotfix for #52 - missing 'end'!

### DIFF
--- a/files/default/slack_handler_util.rb
+++ b/files/default/slack_handler_util.rb
@@ -50,7 +50,11 @@ class SlackHandlerUtil
   def run_status_cookbook_detail(context = {})
     case context['cookbook_detail_level'] || @default_config[:cookbook_detail_level]
     when "all"
-      cookbooks = run_context.cookbook_collection
+      cookbooks = if Chef.respond_to?(:run_context)
+                    Chef.run_context.cookbook_collection
+                  else
+                    run_context.cookbook_collection
+                  end
       " using cookbooks #{cookbooks.values.map { |x| x.name.to_s + ' ' + x.version }}"
     end
   end

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ maintainer_email 'rackspace-cookbooks@rackspace.com'
 license          'Apache-2.0'
 description      'Installs/Configures a Chef handler for reporting results to a Slack channel.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.9.0'
+version          '0.9.1'
 
 depends 'chef_handler', '~> 2.1.2'
 


### PR DESCRIPTION
Apologies - I missed the `end` to my `if` block.

I did not bump the cookbook version on my branch for #52 when testing, so Berkshelf did not actually use my change when validating. 

I've included a bump to `0.9.1` here.

Resolves #53.
