### PR TITLE
Round elapsed time

### DIFF
--- a/files/default/slack_handler_util.rb
+++ b/files/default/slack_handler_util.rb
@@ -61,11 +61,12 @@ class SlackHandlerUtil
 
   def run_status_message_detail(context = {})
     updated_resources = @run_status.updated_resources
+    elapsed_time = @run_status.elapsed_time.round
     case context['message_detail_level'] || @default_config[:message_detail_level]
     when "elapsed"
-      " (#{@run_status.elapsed_time.round} seconds). #{updated_resources.count} resources updated" unless updated_resources.nil?
+      ". #{updated_resources.count} resources updated in #{elapsed_time} seconds." unless updated_resources.nil?
     when "resources"
-      " (#{@run_status.elapsed_time.round} seconds). #{updated_resources.count} resources updated \n #{updated_resources.join(', ')}" unless updated_resources.nil?
+      ". #{updated_resources.count} resources updated in #{elapsed_time} seconds:\n#{updated_resources.join(', ')}" unless updated_resources.nil?
     end
   end
 end

--- a/files/default/slack_handler_util.rb
+++ b/files/default/slack_handler_util.rb
@@ -63,9 +63,9 @@ class SlackHandlerUtil
     updated_resources = @run_status.updated_resources
     case context['message_detail_level'] || @default_config[:message_detail_level]
     when "elapsed"
-      " (#{@run_status.elapsed_time} seconds). #{updated_resources.count} resources updated" unless updated_resources.nil?
+      " (#{@run_status.elapsed_time.round} seconds). #{updated_resources.count} resources updated" unless updated_resources.nil?
     when "resources"
-      " (#{@run_status.elapsed_time} seconds). #{updated_resources.count} resources updated \n #{updated_resources.join(', ')}" unless updated_resources.nil?
+      " (#{@run_status.elapsed_time.round} seconds). #{updated_resources.count} resources updated \n #{updated_resources.join(', ')}" unless updated_resources.nil?
     end
   end
 end


### PR DESCRIPTION
Reporting the elapsed time down to the nanosecond is a bit overkill, round to the closest second looks nicer.

Before:
> Chef run succeeded on node webserver (9.062432019 seconds). 3 resources updated

After:
> Chef run succeeded on node webserver. 3 resources updated in 9 seconds.

Matches better with the official cli output:
> Chef Client finished, 3/23 resources updated in 9 seconds
