### PR TITLE
Fix webhook handler

### DIFF
--- a/files/default/slack_handler_webhook.rb
+++ b/files/default/slack_handler_webhook.rb
@@ -47,16 +47,16 @@ class Chef::Handler::Slack < Chef::Handler
   def report
     setup_run_status(run_status)
 
-    @webhooks['name'].each do |val|
+    @webhooks[:name].each do |val|
       Chef::Log.debug("Sending handler report to webhook #{val}")
-      webhook = node['chef_client']['handler']['slack']['webhooks'][val]
+      webhook = node[:chef_client][:handler][:slack][:webhooks][val]
       Timeout.timeout(@timeout) do
         sending_to_slack = if @run_status.is_a?(Chef::RunStatus)
                              report_chef_run_end(webhook)
                            else
                              report_chef_run_start(webhook)
                            end
-        Chef::Log.info("Sending report to Slack webhook #{webhook['url']}") if sending_to_slack
+        Chef::Log.info("Sending report to Slack webhook #{webhook[:url]}") if sending_to_slack
       end
     end
   rescue Exception => e
@@ -67,15 +67,15 @@ class Chef::Handler::Slack < Chef::Handler
 
   def report_chef_run_start(webhook)
     return false unless @util.send_on_start(webhook)
-    slack_message(" :gear: #{@util.start_message(webhook)}", webhook['url'])
+    slack_message(" :gear: #{@util.start_message(webhook)}", webhook[:url])
   end
 
   def report_chef_run_end(webhook)
     if @run_status.success?
       return false if @util.fail_only(webhook)
-      slack_message(" :white_check_mark: #{@util.end_message(webhook)}", webhook['url'])
+      slack_message(" :white_check_mark: #{@util.end_message(webhook)}", webhook[:url])
     else
-      slack_message(" :skull: #{@util.end_message(webhook)}", webhook['url'], run_status.exception)
+      slack_message(" :skull: #{@util.end_message(webhook)}", webhook[:url], run_status.exception)
     end
   end
 

--- a/files/default/slack_handler_webhook.rb
+++ b/files/default/slack_handler_webhook.rb
@@ -49,7 +49,7 @@ class Chef::Handler::Slack < Chef::Handler
 
     @webhooks[:name].each do |val|
       Chef::Log.debug("Sending handler report to webhook #{val}")
-      webhook = node[:chef_client][:handler][:slack][:webhooks][val]
+      webhook = @webhooks[val.intern]
       Timeout.timeout(@timeout) do
         sending_to_slack = if @run_status.is_a?(Chef::RunStatus)
                              report_chef_run_end(webhook)

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ maintainer_email 'rackspace-cookbooks@rackspace.com'
 license          'Apache-2.0'
 description      'Installs/Configures a Chef handler for reporting results to a Slack channel.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.9.1'
+version          '0.9.2'
 
 depends 'chef_handler', '~> 2.1.2'
 


### PR DESCRIPTION
To be able to use the webhook handler directly from client.rb/solo.rb (where no HashWithIndifferentAccess is used) i made a few changes. 

This mostly means using hash symbols everywhere instead of a mix of strings and symbols.

Now you can do the following (for example):

```
require '/etc/chef/local-mode-cache/handlers/slack_handler_webhook.rb'                                        
config = { webhooks: {                                                                                        
                name: [ "sembot" ],                                                                           
                sembot: {                                                                                     
                        url: "https://hooks.slack.com/services/XXX'  
                }                                                                                             
        },                                                                                                    
        username: "I am a bot",
        icon_url: "https://avatars1.githubusercontent.com/u/29740",
        fail_only: false,
        send_start_message: true,
        message_detail_level: "resources",
        cookbook_detail_level: 'all',
        send_environment: false,
        send_organization: false
}

slack_handler = Chef::Handler::Slack.new(config)

start_handlers << slack_handler
exception_handlers << slack_handler
report_handlers << slack_handler
```
