### PR TITLE
Modernize the metadata

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -6,8 +6,8 @@ provisioner:
   name: chef_zero
 
 platforms:
-  - name: centos-6.9
-  - name: ubuntu-14.04
+  - name: centos-7
+  - name: ubuntu-18.04
 
 
 suites:

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,6 @@ maintainer       'Rackspace'
 maintainer_email 'rackspace-cookbooks@rackspace.com'
 license          'Apache-2.0'
 description      'Installs/Configures a Chef handler for reporting results to a Slack channel.'
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 
 version          '1.0.0'
 
@@ -15,6 +14,6 @@ supports 'redhat'
 supports 'debian'
 supports 'windows'
 
-source_url 'https://github.com/rackspace-cookbooks/chef-slack_handler' if respond_to?(:source_url)
-issues_url 'https://github.com/rackspace-cookbooks/chef-slack_handler/issues' if respond_to?(:issues_url)
-chef_version '>= 14.0' if respond_to?(:chef_version)
+source_url 'https://github.com/rackspace-cookbooks/chef-slack_handler'
+issues_url 'https://github.com/rackspace-cookbooks/chef-slack_handler/issues'
+chef_version '>= 14.0'


### PR DESCRIPTION
Remove the if_respond to backwards compatibility with old Chef 12 releases. Also remove long_description, which is no longer recommended.

Signed-off-by: Tim Smith <tsmith@chef.io>